### PR TITLE
Use UUID for the generated callback script (#14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
-        "react": "^18.2.0"
+        "react": "^18.2.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.9",
@@ -8066,6 +8067,18 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/msaracevic/react-embed-gist#readme",
   "dependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "uuid": "^9.0.1"
   },
   "babel": {
     "presets": [

--- a/src/ReactEmbedGist.js
+++ b/src/ReactEmbedGist.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { v4 as uuid } from "uuid";
 
 export default class ReactEmbedGist extends Component {
   constructor(props) {
@@ -8,6 +9,7 @@ export default class ReactEmbedGist extends Component {
       loading: true,
       title: "",
       content: "",
+      instanceId: uuid().replace(/-/g, ""),
     };
 
     this.handleNetworkErrors = this.handleNetworkErrors.bind(this);
@@ -39,7 +41,7 @@ export default class ReactEmbedGist extends Component {
     this.setupCallback(id);
 
     const script = document.createElement("script");
-    let url = `https://gist.github.com/${gist}.json?callback=gist_callback_${id}`;
+    let url = `https://gist.github.com/${gist}.json?callback=gist_callback_${this.state.instanceId}`;
     if (file) url += `&file=${file}`;
     script.type = "text/javascript";
     script.src = url;
@@ -59,7 +61,7 @@ export default class ReactEmbedGist extends Component {
   }
 
   setupCallback(id) {
-    window[`gist_callback_${id}`] = function (gist) {
+    window[`gist_callback_${this.state.instanceId}`] = function (gist) {
       /*
        * Once we call this callback, we are going to set description of gist as title and fill the content. We are
        * also going to set loading flag into false to render the content


### PR DESCRIPTION
This fixes issue #14 by replacing the id of the callback with a UUID, which results in duplicating some injected code but allows multiple files from the same gist to be loaded on the same page.